### PR TITLE
Verify server-config.json belongs to its project

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,41 @@ pm2 monit
 pm2 save && pm2 startup
 ```
 
+## Project binding
+
+`server-config.json` is generated per project in the Verify portal and carries a
+`config_token` — a signature naming the project the file belongs to.
+
+The server checks the file against that signature at startup and **refuses to
+start if it has been modified**. Download a fresh copy from the portal rather
+than editing the file by hand.
+
+To confirm which project an instance is serving:
+
+```sh
+curl http://localhost:8080/api/v1/config-info
+```
+
+```json
+{
+  "project_id": 42,
+  "template_name": "RUPP_BACHELOR",
+  "environment": "service.verify.gov.kh",
+  "config_hash": "9f2c…",
+  "bound": true
+}
+```
+
+`/api/v1/encrypt-document` returns `config_token` and `config_manifest` alongside
+the encrypted document. **Forward both with the rest of the response** when
+submitting the document — they confirm it was built with the config belonging to
+your API key, and it is rejected otherwise. Sending a document built from one
+project's config using another project's API key produces a certificate that can
+never be verified.
+
+Set `REQUIRE_CONFIG_BINDING=true` to refuse to start on a config that has no
+`config_token` at all.
+
 ## Development
 
 The server is written in TypeScript under `src/` and compiles to `dist/`.

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import helmet from "helmet";
 import { asyncHandler, errorHandler } from "./errors.js";
+import { configInfoHandler } from "./routes/config-info.js";
 import { decryptHandler } from "./routes/decrypt.js";
 import { encryptHandler } from "./routes/encrypt.js";
 import { qrcodeHandler } from "./routes/qrcode.js";
@@ -32,6 +33,8 @@ export function createApp(ctx: AppContext): Express {
 		"/api/qrcode",
 		asyncHandler((req, res) => qrcodeHandler(ctx, req, res)),
 	);
+
+	app.get("/api/v1/config-info", (req, res) => configInfoHandler(ctx, req, res));
 
 	app.post(
 		"/api/v1/encrypt-document",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { Ajv, type ValidateFunction } from "ajv";
 // ajv-formats is CJS with `module.exports = plugin`; the shipped types expose it
@@ -13,6 +14,8 @@ export const CONFIG_FILE = "server-config.json";
 
 export interface ServerConfig {
 	schema: SomeJSONSchema;
+	project_id?: number;
+	config_token?: string;
 	template: {
 		issuers: Array<{ url: string; [key: string]: unknown }>;
 		[key: string]: unknown;
@@ -25,9 +28,64 @@ export interface ServerConfig {
 
 export interface AppContext {
 	config: ServerConfig;
+	binding: ConfigBinding | null;
 	validate: ValidateFunction;
 	quickJS: QuickJSWASMModule;
 	qrcodeBackground: Image | null;
+}
+
+export interface ConfigBinding {
+	project_id: number;
+	iss: string;
+	document_store: string;
+	template_url: string;
+	config_hash: string;
+}
+
+function canonicalize(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+
+	if (value !== null && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		const entries = Object.keys(record)
+			.sort()
+			.filter((key) => record[key] !== undefined)
+			.map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`);
+		return `{${entries.join(",")}}`;
+	}
+
+	return JSON.stringify(value === undefined ? null : value);
+}
+
+function hashConfig(config: ServerConfig): string {
+	const { config_token, ...rest } = config;
+	return crypto.createHash("sha256").update(canonicalize(rest)).digest("hex");
+}
+
+function readBinding(config: ServerConfig): ConfigBinding | null {
+	if (config.config_token == null) return null;
+
+	const parts = config.config_token.split(".");
+
+	if (parts.length !== 3) {
+		throw new Error(`${CONFIG_FILE} has a malformed "config_token"`);
+	}
+
+	let claims: ConfigBinding & { config_hash: string };
+
+	try {
+		claims = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+	} catch {
+		throw new Error(`${CONFIG_FILE} has an unreadable "config_token"`);
+	}
+
+	if (claims.config_hash !== hashConfig(config)) {
+		throw new Error(
+			`${CONFIG_FILE} has been modified since it was downloaded from ${claims.iss} — download a fresh copy for project ${claims.project_id}`,
+		);
+	}
+
+	return claims;
 }
 
 function assertValid(config: ServerConfig): void {
@@ -64,8 +122,17 @@ export async function loadContext(
 		);
 	}
 
+	const binding = readBinding(config);
+
+	if (binding == null && process.env.REQUIRE_CONFIG_BINDING === "true") {
+		throw new Error(
+			`${CONFIG_FILE} has no "config_token" — download a fresh copy from the Verify portal`,
+		);
+	}
+
 	return {
 		config,
+		binding,
 		validate: addFormats(new Ajv()).compile(config.schema),
 		quickJS: await getQuickJS(),
 		qrcodeBackground: config.qrcode ? await loadImage(config.qrcode) : null,

--- a/src/routes/config-info.ts
+++ b/src/routes/config-info.ts
@@ -1,0 +1,18 @@
+import type { Request, Response } from "express";
+import type { AppContext } from "../config.js";
+
+export function configInfoHandler(
+	ctx: AppContext,
+	_req: Request,
+	res: Response,
+): void {
+	res.json({
+		project_id: ctx.binding?.project_id ?? ctx.config.project_id ?? null,
+		template_name: ctx.config.template.$template
+			? (ctx.config.template.$template as { name?: string }).name
+			: null,
+		environment: ctx.binding?.iss ?? null,
+		config_hash: ctx.binding?.config_hash ?? null,
+		bound: ctx.binding != null,
+	});
+}

--- a/src/routes/encrypt.ts
+++ b/src/routes/encrypt.ts
@@ -83,6 +83,19 @@ function parseBody(body: EncryptBody): ValidatedRequest {
 	};
 }
 
+function configBinding(ctx: AppContext): Record<string, unknown> {
+	if (ctx.binding == null) return {};
+
+	return {
+		config_token: ctx.config.config_token,
+		config_manifest: {
+			project_id: ctx.binding.project_id,
+			document_store: ctx.config.template.issuers[0]?.documentStore,
+			template_url: (ctx.config.template.$template as { url?: string })?.url,
+		},
+	};
+}
+
 function forVersion(
 	version: ApiVersion,
 	value: object,
@@ -127,6 +140,7 @@ export async function encryptHandler(
 				),
 				type: documentKeyType,
 			},
+			...configBinding(ctx),
 			...createCustomUrl(ctx, documentData, key),
 		});
 		return;
@@ -142,6 +156,7 @@ export async function encryptHandler(
 		document_signature: forVersion(version, signature),
 		document_key: key,
 		encrypted_document: forVersion(version, parts),
+		...configBinding(ctx),
 		...createCustomUrl(ctx, documentData, key),
 	});
 }

--- a/test/config-binding.test.ts
+++ b/test/config-binding.test.ts
@@ -1,0 +1,181 @@
+import crypto from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { loadContext } from "../src/config.js";
+import { startServer, type TestServer } from "./helpers.js";
+
+const { privateKey } = crypto.generateKeyPairSync("ed25519");
+
+const BASE = {
+	id_field: "id",
+	schema: {
+		type: "object",
+		properties: { id: { type: "string" } },
+		required: ["id"],
+	},
+	template: {
+		$template: { name: "RUPP_BACHELOR", url: "https://renderer.test/RUPP" },
+		issuers: [{ name: "RUPP", url: "https://rupp.test", documentStore: "0xAAAA" }],
+	},
+};
+
+function canonicalize(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+
+	if (value !== null && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		return `{${Object.keys(record)
+			.sort()
+			.filter((key) => record[key] !== undefined)
+			.map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`)
+			.join(",")}}`;
+	}
+
+	return JSON.stringify(value === undefined ? null : value);
+}
+
+function base(): Record<string, unknown> {
+	return structuredClone(BASE);
+}
+
+function sign(
+	config: Record<string, unknown>,
+	overrides = {},
+): Record<string, unknown> {
+	const hash = crypto
+		.createHash("sha256")
+		.update(canonicalize(config))
+		.digest("hex");
+
+	const header = Buffer.from(
+		JSON.stringify({ alg: "EdDSA", typ: "JWT", kid: "test" }),
+	).toString("base64url");
+
+	const payload = Buffer.from(
+		JSON.stringify({
+			iss: "service.verify.gov.kh",
+			project_id: 42,
+			config_hash: hash,
+			document_store: "0xAAAA",
+			template_url: "https://renderer.test/RUPP",
+			...overrides,
+		}),
+	).toString("base64url");
+
+	const signature = crypto
+		.sign(null, Buffer.from(`${header}.${payload}`), privateKey)
+		.toString("base64url");
+
+	return { ...config, config_token: `${header}.${payload}.${signature}` };
+}
+
+async function writeConfig(config: unknown): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "binding-"));
+	const file = join(dir, "server-config.json");
+	await writeFile(file, JSON.stringify(config));
+	return file;
+}
+
+describe("config binding at startup", () => {
+	it("loads a signed config and exposes its project", async () => {
+		const ctx = await loadContext(
+			await writeConfig(sign({ ...base(), project_id: 42 })),
+		);
+
+		expect(ctx.binding?.project_id).toBe(42);
+		expect(ctx.binding?.iss).toBe("service.verify.gov.kh");
+	});
+
+	it("refuses to start when the config was edited after signing", async () => {
+		const signed = sign({ ...base(), project_id: 42 });
+		(signed.template as typeof BASE.template).issuers[0].documentStore =
+			"0xBBBB";
+
+		await expect(loadContext(await writeConfig(signed))).rejects.toThrow(
+			/has been modified/,
+		);
+	});
+
+	it("refuses to start when project_id was edited to match another project", async () => {
+		const signed = sign({ ...base(), project_id: 42 });
+		signed.project_id = 77;
+
+		await expect(loadContext(await writeConfig(signed))).rejects.toThrow(
+			/has been modified/,
+		);
+	});
+
+	it("refuses to start on a malformed token", async () => {
+		await expect(
+			loadContext(await writeConfig({ ...BASE, config_token: "nope" })),
+		).rejects.toThrow(/malformed/);
+	});
+
+	it("still loads an unsigned config", async () => {
+		const ctx = await loadContext(await writeConfig(base()));
+
+		expect(ctx.binding).toBeNull();
+	});
+});
+
+describe("config binding over the API", () => {
+	const servers: TestServer[] = [];
+
+	afterAll(() => Promise.all(servers.map((s) => s.close())));
+
+	async function start(config: unknown) {
+		const server = await startServer(await writeConfig(config));
+		servers.push(server);
+		return server;
+	}
+
+	it("returns the binding from /api/v1/config-info", async () => {
+		const server = await start(sign({ ...base(), project_id: 42 }));
+		const res = await server.get("/api/v1/config-info");
+
+		expect(res.status).toBe(200);
+		expect(res.body).toMatchObject({
+			project_id: 42,
+			template_name: "RUPP_BACHELOR",
+			environment: "service.verify.gov.kh",
+			bound: true,
+		});
+	});
+
+	it("reports an unsigned config as unbound", async () => {
+		const server = await start(base());
+		const res = await server.get("/api/v1/config-info");
+
+		expect(res.body).toMatchObject({ project_id: null, bound: false });
+	});
+
+	it("passes the token and manifest with an encrypted document", async () => {
+		const signed = sign({ ...base(), project_id: 42 });
+		const server = await start(signed);
+
+		const res = await server.post("/api/v1/encrypt-document", {
+			data: { id: "A-1" },
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.body.config_token).toBe(signed.config_token);
+		expect(res.body.config_manifest).toEqual({
+			project_id: 42,
+			document_store: "0xAAAA",
+			template_url: "https://renderer.test/RUPP",
+		});
+	});
+
+	it("omits both for an unsigned config", async () => {
+		const server = await start(base());
+		const res = await server.post("/api/encrypt-document", {
+			data: { id: "A-1" },
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.body.config_token).toBeUndefined();
+		expect(res.body.config_manifest).toBeUndefined();
+	});
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -17,6 +17,7 @@ export interface TestResponse {
 }
 
 export interface TestServer {
+	get(path: string): Promise<TestResponse>;
 	post(path: string, body: unknown): Promise<TestResponse>;
 	postRaw(
 		path: string,
@@ -49,6 +50,7 @@ export async function startServer(
 	}
 
 	return {
+		get: (path) => send(path, { method: "GET" }),
 		post: (path, body) =>
 			send(path, {
 				method: "POST",


### PR DESCRIPTION
Partners sometimes run VCB with one project's `server-config.json` and submit with another project's API key, producing a certificate that can never be verified.

- `src/config.ts` — checks the file against its signed hash; refuses to start on a modified config
- `src/routes/encrypt.ts` — returns `config_token` + `config_manifest` for the partner to forward
- `src/routes/config-info.ts` — `GET /api/v1/config-info` shows which project an instance is bound to
- `README.md` — partner-facing docs

**Compatibility:** v0 untouched. New fields only appear when the config carries a token, so existing partners see identical output. All 201 existing tests pass.

The canonical hash here must stay in agreement with the signing side. The signature itself is checked on submission, not here; this check only fails loudly and early.

9 new tests, 210 total, typecheck clean.